### PR TITLE
Use File.exist? instead of deprecated File.exists?.

### DIFF
--- a/lib/linner/bundler.rb
+++ b/lib/linner/bundler.rb
@@ -22,9 +22,9 @@ module Linner
     end
 
     def check
-      return [false, "Bundles didn't exsit!"] unless File.exists? REPOSITORY
+      return [false, "Bundles didn't exsit!"] unless File.exist? REPOSITORY
       @bundles.each do |bundle|
-        unless File.exists?(bundle.path) and File.exists?(File.join(VENDOR, bundle.name))
+        unless File.exist?(bundle.path) and File.exist?(File.join(VENDOR, bundle.name))
           return [false, "Bundle #{bundle.name} v#{bundle.version} didn't match!"]
         end
       end
@@ -32,12 +32,12 @@ module Linner
     end
 
     def install
-      unless File.exists? REPOSITORY
+      unless File.exist? REPOSITORY
         FileUtils.mkdir_p(REPOSITORY)
       end
       @bundles.each do |bundle|
         if bundle.version != "master"
-          next if File.exists?(bundle.path) and File.exists?(File.join(VENDOR, bundle.name))
+          next if File.exist?(bundle.path) and File.exist?(File.join(VENDOR, bundle.name))
         end
         puts "Installing #{bundle.name} #{bundle.version}..."
         install_to_repository bundle.url, bundle.path

--- a/lib/linner/environment.rb
+++ b/lib/linner/environment.rb
@@ -20,7 +20,7 @@ module Linner
 
     def watched_paths
       [app_folder, vendor_folder, test_folder].select do |path|
-        File.exists? path
+        File.exist? path
       end
     end
 


### PR DESCRIPTION
This will fix the warning that introduced since Ruby 2.1.0 of File.exists?:

``` c
static VALUE
rb_file_exists_p(VALUE obj, VALUE fname)
{
    const char *s = "FileTest#";
    if (obj == rb_mFileTest) {
        s = "FileTest.";
    }
    else if (obj == rb_cFile ||
             (RB_TYPE_P(obj, T_CLASS) &&
              RTEST(rb_class_inherited_p(obj, rb_cFile)))) {
        s = "File.";
    }
    rb_warning("%sexists? is a deprecated name, use %sexist? instead", s, s);
    return rb_file_exist_p(obj, fname);
}
```

Ref. http://www.ruby-doc.org/core-2.1.0/File.html#method-c-exists-3F
